### PR TITLE
ヘッダーのmiyashiiiiロゴ位置を修正

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,11 +1,13 @@
 <template>
   <q-header class="bg-grey-3">
     <q-toolbar class="" >
-      <q-toolbar-title class="text-center">
+      <q-space />
+      <q-toolbar-title class="flex justify-center">
         <NuxtLink to="/">
           <q-img src="/logo.png" style="width: 128px" no-spinner />
         </NuxtLink>
       </q-toolbar-title>
+      <q-space />
       <q-btn
         flat
         round


### PR DESCRIPTION
## 概要
Gitアイコン追加の影響でロゴが中央からズレていた問題を解決。

## 変更内容
- q-spaceコンポーネントを使用してflexboxレイアウトを調整
- ロゴを適切に中央配置するよう修正

Closes #370

⚡ Generated with [Claude Code](https://claude.ai/code)