### PR TITLE
スマホでフッターが横切れする問題を修正

### DIFF
--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -1,69 +1,108 @@
 <template>
-  <q-footer class="text-white" style="background-color: #5694b3">
-    <q-toolbar class="row justify-center">
-      <q-tabs
-        no-caps
-        indicator-color="white"
-        class="text-white"
-        v-model="tab"
-        switch-indicator
+  <footer class="app-footer">
+    <nav class="footer-nav">
+      <NuxtLink to="/" class="footer-item" :class="{ active: isActive('/') }">
+        <q-icon name="home" size="sm" />
+        <span>Top</span>
+      </NuxtLink>
+      <NuxtLink to="/posts" class="footer-item" :class="{ active: isActive('/posts') }">
+        <q-icon name="description" size="sm" />
+        <span>Posts</span>
+      </NuxtLink>
+      <NuxtLink to="/works" class="footer-item" :class="{ active: isActive('/works') }">
+        <q-icon name="palette" size="sm" />
+        <span>Works</span>
+      </NuxtLink>
+      <NuxtLink to="/tools" class="footer-item" :class="{ active: isActive('/tools') }">
+        <q-icon name="build" size="sm" />
+        <span>Tools</span>
+      </NuxtLink>
+      <NuxtLink
+        to="https://github.com/miyashiiii/miyashiiii.github.io"
+        class="footer-item"
+        target="_blank"
       >
-        <NuxtLink to="/" class="no-decoration text-white">
-          <q-tab name="index" class="q-py-xs footer-tab">
-            <q-icon name="home" size="sm" />
-            Top
-          </q-tab>
-        </NuxtLink>
-        <NuxtLink to="/posts" class="no-decoration text-white">
-          <q-tab name="posts" class="q-py-xs footer-tab">
-            <q-icon name="description" size="sm" />
-            Posts
-          </q-tab>
-        </NuxtLink>
-        <NuxtLink to="/works" class="no-decoration text-white">
-          <q-tab name="works" class="q-py-xs footer-tab">
-            <q-icon name="palette" size="sm" />
-            Works
-          </q-tab>
-        </NuxtLink>
-        <NuxtLink to="/tools" class="no-decoration text-white">
-          <q-tab name="tools" class="q-py-xs footer-tab">
-            <q-icon name="build" size="sm" />
-            Tools
-          </q-tab>
-        </NuxtLink>
-        <NuxtLink
-          to="https://github.com/miyashiiii/miyashiiii.github.io"
-          class="no-decoration text-white"
-          target="_blank"
-        >
-          <div class="col q-py-xs footer-tab">
-            <div class="row justify-center">
-              <q-icon name="fa-brands fa-git-alt" size="sm" />
-            </div>
-            <div class="text-center">Source <q-icon name="open_in_new" /></div>
-          </div>
-        </NuxtLink>
-      </q-tabs>
-    </q-toolbar>
-  </q-footer>
+        <q-icon name="fa-brands fa-git-alt" size="sm" />
+        <span>Source <q-icon name="open_in_new" size="xs" /></span>
+      </NuxtLink>
+    </nav>
+  </footer>
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
-
-const tab = ref("works");
 const route = useRoute();
 
-watchEffect(() => {
-  if (route.path === "/") {
-    tab.value = "index";
-  } else if (route.path.startsWith("/posts")) {
-    tab.value = "posts";
-  } else if (route.path === "/works") {
-    tab.value = "works";
-  } else if (route.path.startsWith("/tools")) {
-    tab.value = "tools";
+const isActive = (path: string) => {
+  if (path === "/") {
+    return route.path === "/";
   }
-});
+  return route.path.startsWith(path);
+};
 </script>
+
+<style scoped>
+.app-footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #5694b3;
+  color: white;
+  z-index: 1000;
+}
+
+.footer-nav {
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  padding: 0;
+  margin: 0;
+  min-height: 56px;
+}
+
+.footer-item {
+  flex: 1;
+  max-width: 19%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  padding: 6px 4px 8px 4px;
+  color: white;
+  text-decoration: none;
+  position: relative;
+  transition: opacity 0.2s;
+}
+
+.footer-item:hover {
+  opacity: 0.8;
+}
+
+.footer-item span {
+  font-size: 0.75rem;
+  text-align: center;
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+}
+
+/* アクティブな項目の上に白いバーを表示 */
+.footer-item.active::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background-color: white;
+}
+
+/* PC表示の場合は幅を制限 */
+@media (min-width: 1024px) {
+  .footer-nav {
+    max-width: 600px;
+    margin: 0 auto;
+  }
+}
+</style>


### PR DESCRIPTION
## 概要

スマホ表示でフッターのタブが横に切れる問題を修正しました。

## 変更内容

- QuasarのコンポーネントをやめてピュアCSSで実装
- 各タブを19%の幅で均等配置し、画面内に収まるように調整
- PC表示では最大600pxに制限して、タブ間が詰まるように改善
- アクティブなタブの上部に白いインジケーターバーを表示

## テスト

- スマホ表示でフッターが横切れしないことを確認
- PC表示でタブが適切な間隔で表示されることを確認
- アクティブなタブに白いバーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)